### PR TITLE
Use b.graph.host instead of b.host

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,7 +35,7 @@ pub fn build(b: *std.Build) void {
     // any Emscripten header search path shenanigans
     const translateC = b.addTranslateC(.{
         .root_source_file = b.path("src/cimgui.h"),
-        .target = b.host,
+        .target = b.graph.host,
         .optimize = optimize,
     });
 


### PR DESCRIPTION
b.host was deprecated in 0.13.0 and removed in https://github.com/ziglang/zig/pull/20388