### PR TITLE
Add missing cimgui_internal.cpp to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ if (FIPS_IMPORT)
     fips_begin_lib(imgui)
     fips_files(
         src/cimgui.cpp
+        src/cimgui_internal.cpp
         src/imgui_demo.cpp
         src/imgui_draw.cpp
         src/imgui_tables.cpp
@@ -12,6 +13,7 @@ if (FIPS_IMPORT)
     fips_begin_lib(imgui-docking)
     fips_files(
         src-docking/cimgui.cpp
+        src-docking/cimgui_internal.cpp
         src-docking/imgui_demo.cpp
         src-docking/imgui_draw.cpp
         src-docking/imgui_tables.cpp
@@ -24,6 +26,7 @@ else()
     project(dcimgui)
     add_library(imgui
         src/cimgui.cpp
+        src/cimgui_internal.cpp
         src/imgui_demo.cpp
         src/imgui_draw.cpp
         src/imgui_tables.cpp
@@ -31,6 +34,7 @@ else()
         src/imgui.cpp)
     add_library(imgui-docking
         src-docking/cimgui.cpp
+        src-docking/cimgui_internal.cpp
         src-docking/imgui_demo.cpp
         src-docking/imgui_draw.cpp
         src-docking/imgui_tables.cpp


### PR DESCRIPTION
Bring CMakeLists.txt in line with build.zig by adding cimgui_internal.cpp to all library configurations. This was missing despite being part of the source list since PR #5 (July 2025) which added internal API exposure.

The build.zig correctly includes cimgui_internal.cpp in imgui_sources, but CMakeLists.txt was never updated to match. This affects CMake/fips users who would be missing internal API implementations.

Changes:
- Add src/cimgui_internal.cpp to both fips and non-fips imgui libraries
- Add src-docking/cimgui_internal.cpp to both imgui-docking libraries