### PR TITLE
use IMGUI_USE_WCHAR32 for font glyph ranges

### DIFF
--- a/src-docking/imconfig.h
+++ b/src-docking/imconfig.h
@@ -145,3 +145,5 @@ namespace ImGui
     void MyFunction(const char* name, MyMatrix44* mtx);
 }
 */
+
+#define IMGUI_USE_WCHAR32

--- a/src/imconfig.h
+++ b/src/imconfig.h
@@ -145,3 +145,5 @@ namespace ImGui
     void MyFunction(const char* name, MyMatrix44* mtx);
 }
 */
+
+#define IMGUI_USE_WCHAR32


### PR DESCRIPTION
ImWchar [configurable type: override in imconfig.h with '#define IMGUI_USE_WCHAR32' to support Unicode planes 1-16]